### PR TITLE
feat(Performance): Parallelize the image conversion

### DIFF
--- a/HeicToJpg.csproj
+++ b/HeicToJpg.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>
       win10-x64;
     </RuntimeIdentifiers>

--- a/Program.cs
+++ b/Program.cs
@@ -1,29 +1,44 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using ImageMagick;
 
 namespace HeicToJpg
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            foreach (string fileName in Directory.GetFiles("./input/"))
+            var files = Directory.GetFiles("./input/");
+
+            await Parallel.ForEachAsync(files, async (fileName, _) => await ConvertFile(fileName));
+        }
+
+        private static async Task ConvertFile(string fileName)
+        {
+            string ext = Path.GetExtension(fileName).ToLowerInvariant();
+            if (ext == ".heic")
             {
-                string ext = Path.GetExtension(fileName);
-                if (ext == ".HEIC" || ext == ".heic")
-                {
-                    Console.WriteLine($"Found {Path.GetFileName(fileName)}. Converting to JPG...");
-                    using (var image = new MagickImage(fileName))
-                    {
-                        image.Format = MagickFormat.Jpg;
-                        image.Write($"./output/{Path.GetFileNameWithoutExtension(fileName)}.jpg");
-                    }
-                }
-                else
-                {
-                    Console.WriteLine($"{Path.GetFileName(fileName)} is not .HEIC... Skipping");
-                }
+                Console.WriteLine($"Found {Path.GetFileName(fileName)}. Converting to JPG...");
+                await ConvertHEIC(MagickFormat.Jpg, fileName, "./output");
+            }
+            else
+            {
+                Console.WriteLine($"{Path.GetFileName(fileName)} is not .HEIC... Skipping");
+            }
+        }
+
+        private static async Task ConvertHEIC(MagickFormat convertToFormat, string fileName, string outputPath)
+        {
+            try
+            {
+                using var image = new MagickImage(fileName);
+                image.Format = convertToFormat;
+                await image.WriteAsync($"{outputPath}/{Path.GetFileNameWithoutExtension(fileName)}.jpg");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Could not write: {Path.GetFileName(fileName)}. Error: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
Parallelize the image conversion to take advantage of full CPU capabilities

Upgrade project to .NET6 to allow the usage of , this allows us to not only use full capabilities but to also use MagickImage's async write. To write the new image file asynchronously